### PR TITLE
fix conda config typo property

### DIFF
--- a/anaconda/.condarc
+++ b/anaconda/.condarc
@@ -6,4 +6,4 @@ custom_channels:
   pytorch: https://anaconda.mirrors.sjtug.sjtu.edu.cn/cloud/
 channels:
   - defaults
-how_channel_urls: true
+show_channel_urls: true


### PR DESCRIPTION
update `.condarc`'s `how_channel_urls` to `show_channel_urls`